### PR TITLE
added functionality to add formatted in output channel

### DIFF
--- a/src/modules/client/onSaveCb.ts
+++ b/src/modules/client/onSaveCb.ts
@@ -16,12 +16,11 @@ import * as vscode from 'vscode';
 // require in fs, path, and getRootProjectDir function/module
 const fs = require('fs');
 const path = require('path');
-const getRootProjectDir = require('./getRootProjectDir');
 const sendgRPCRequest = require('./sendgRPCRequest');
 
 const onSave = (
-  document: TextDocument,
-  tropicChannel: OutputChannel,
+  document: vscode.TextDocument,
+  tropicChannel: vscode.OutputChannel,
   tropicConfigPath: string,
   rootDir: string
 ) => {
@@ -62,15 +61,17 @@ const onSave = (
   protoPackage = config.protoPackage;
   requestsArr = Object.values(requests);
 
+  tropicChannel.append('Tropic Results:\n\n');
   // send each request to gRPC handler
-  requestsArr.map((request: object) =>
+  requestsArr.forEach((request: object) =>
     sendgRPCRequest(
       portNumber,
       protoFile,
       protoPackage,
       request.service,
       request.method,
-      request.message
+      request.message,
+      tropicChannel
     )
   );
 };

--- a/src/modules/client/sendgRPCRequest.ts
+++ b/src/modules/client/sendgRPCRequest.ts
@@ -1,6 +1,6 @@
 /**
  * @author : Ed Chow, Shahrukh Khan; July 20, 2020
- * @function : executes the config file, which exports grpc server and proto file data, to be processed
+ * @function : executes gRPC request submitted by user, and displays request and corresponding server result in Tropic output channel
  * @param : {number} port - port of user's running server
  * @param : {string} protoFilePath - absolute path to user's protofile
  * @param : {string} protoPackage - proto package name
@@ -11,9 +11,9 @@
  * @changelog : ##WHOEVER CHANGES THE FILE, date, details
  * * */
 
+import * as vscode from 'vscode';
 const grpc = require('@grpc/grpc-js');
 const protoLoader = require('@grpc/proto-loader');
-const path = require('path');
 
 const sendgRPCRequest = (
   port: number,
@@ -21,21 +21,44 @@ const sendgRPCRequest = (
   protoPackage: string,
   service: string,
   method: string,
-  message: object
+  message: object,
+  tropicChannel: vscode.OutputChannel
 ) => {
+  // read proto file and save as package definition (protocol buffer)
+  // protoLoader compiles proto files into JS
   const packageDef = protoLoader.loadSync(`${protoFilePath}`, {});
+  // read package definition and save as grpc object
   const grpcObject = grpc.loadPackageDefinition(packageDef);
+  // save grpc object's protoPackage object as user package
   const userPackage = grpcObject[`${protoPackage}`];
+  // create a connection to the gRPC server, for a specific service
+  // return an object with all of the methods within that service, and save as client
+  // grpc.credentials.createInsecure(): communication will be in plain text, i.e. non-encrypted
   const client = new userPackage[service](`localhost:${port}`, grpc.credentials.createInsecure());
 
-  client[`${method}`](message, (err, res) => {
+  // invoke client object's method
+  client[`${method}`](message, (err, response) => {
     if (err) console.log('error in grpc request: ', err);
-    console.log('Received from server ' + JSON.stringify(res));
-    return 'Received from server: ' + JSON.stringify(res);
-    // display result in tropic output channel
-    // const tropicChannel = vscode.window.createOutputChannel('Tropic');
-    // tropicChannel.show(true);
-    // tropicChannel.append(JSON.stringify(res));
+
+    // generate formatted Request and Response message string
+    const requestStr = JSON.stringify(
+      {
+        service,
+        method,
+        message,
+      },
+      null,
+      2
+    );
+    const responseStr = JSON.stringify(response, null, 2);
+    const outputMessage = `------------------------\n\nSUBMITTED REQUEST \n${requestStr}\n\nSERVER RESPONSE \n${responseStr}\n\n`;
+
+    // display request and response in tropic output channel
+    tropicChannel.show(true);
+    tropicChannel.append(outputMessage);
+
+    // exit function
+    return null;
   });
 };
 


### PR DESCRIPTION
- onSaveCb.ts
  - updated parameter to be vscode objects
  - updated mapping of requestArr to use forEach, since return of null in sendgRPCRequest function
- sendgRPCRequest.ts
  - added tropicChannel to parameter list
  - added comments to clarify flow of code
  - stringified gRPC response with formatting
  - generated the output channel message 
  - wrote results to output channel 