### PR TITLE
Request edges

### DIFF
--- a/src/modules/client/displayOutputMessage.ts
+++ b/src/modules/client/displayOutputMessage.ts
@@ -1,0 +1,40 @@
+/**
+ * @author : Roseanne Damasco; July 29, 2020
+ * @function : displays request and corresponding server result in Tropic output channel
+ * @param : {object} tropicChannel - reference to Tropic's output channel
+ * @param : {string} service - service of gRPC request
+ * @param : {string} method - method of gRPC request
+ * @param : {object} message - body of gRPC request
+ * @param : {string} responseStr - server response message
+ * @returns : null
+ * @changelog : ##WHOEVER CHANGES THE FILE, date, details
+ * * */
+
+import * as vscode from 'vscode';
+
+const displayOuptMessage = (
+  tropicChannel: vscode.OutputChannel,
+  service: string,
+  method: string,
+  message: object,
+  responseStr: string
+) => {
+  // generate formatted request message string
+  const requestStr = JSON.stringify(
+    {
+      service,
+      method,
+      message,
+    },
+    null,
+    2
+  );
+
+  // focus output to tropic channel, and display request input
+  const outputTemplate = `------------------------\n\nSUBMITTED REQUEST \n${requestStr}\n\nSERVER RESPONSE \n${responseStr}\n\n`;
+  tropicChannel.show(true);
+  tropicChannel.append(outputTemplate);
+  return null;
+};
+
+module.exports = displayOuptMessage;

--- a/src/modules/client/sendgRPCRequest.ts
+++ b/src/modules/client/sendgRPCRequest.ts
@@ -1,12 +1,14 @@
 /**
  * @author : Ed Chow, Shahrukh Khan; July 20, 2020
- * @function : executes gRPC request submitted by user, and displays request and corresponding server result in Tropic output channel
+ * @function : executes gRPC request submitted by user
  * @param : {number} port - port of user's running server
+ * @param : {string} ipAddress - IP address of user's running server
  * @param : {string} protoFilePath - absolute path to user's protofile
  * @param : {string} protoPackage - proto package name
  * @param : {string} service - service of gRPC to call
  * @param : {string} method - method of gRPC endpoint to invoke
  * @param : {object} message - body of request to send
+ * @param : {object} tropicChannel - reference to Tropic's output channel
  * @returns : null
  * @changelog : ##WHOEVER CHANGES THE FILE, date, details
  * * */
@@ -14,6 +16,7 @@
 import * as vscode from 'vscode';
 const grpc = require('@grpc/grpc-js');
 const protoLoader = require('@grpc/proto-loader');
+const displayOutputMessage = require('./displayOutputMessage');
 
 const sendgRPCRequest = (
   port: number,
@@ -26,12 +29,40 @@ const sendgRPCRequest = (
   tropicChannel: vscode.OutputChannel
 ) => {
   // read proto file and save as package definition (protocol buffer)
-  // protoLoader compiles proto files into JS
+  // protoLoader compiles proto files into JS object
   const packageDef = protoLoader.loadSync(`${protoFilePath}`, {});
-  // read package definition and save as grpc object
+  console.log('packageDef: ', packageDef, '\n\n');
+  // read package definition and save packages in a grpc object
   const grpcObject = grpc.loadPackageDefinition(packageDef);
-  // save grpc object's protoPackage object as user package
+  console.log('grpcObject: ', grpcObject, '\n\n');
+  // confirm that inputed protoPackage exist in proto file
+  if (!grpcObject.hasOwnProperty(protoPackage)) {
+    // if not, inform user of error
+    const responseStr = `ERROR:Proto package ${protoPackage} was not found in your proto file\n\n`;
+    displayOutputMessage(tropicChannel, service, method, message, responseStr);
+    return null;
+  }
+
+  // confirm that inputed service exist in proto package
+  if (!packageDef.hasOwnProperty(`${protoPackage}.${service}`)) {
+    // if not, inform user of error
+    const responseStr = `ERROR: Service ${service} was not found in ${protoPackage}\n\n`;
+    displayOutputMessage(tropicChannel, service, method, message, responseStr);
+    return null;
+  }
+
+  //
   const userPackage = grpcObject[`${protoPackage}`];
+  console.log('userPackage: ', userPackage, '\n\n');
+
+  // confirm that inputed method exist in service
+  if (!packageDef[`${protoPackage}.${service}`][method]) {
+    // if not, inform user that method is not included in their specified service
+    const responseStr = `ERROR: Method '${method}' was not found in '${service}' service\n\n`;
+    displayOutputMessage(tropicChannel, service, method, message, responseStr);
+    return null;
+  }
+
   // create a connection to the gRPC server, for a specific service
   // return an object with all of the methods within that service, and save as client
   // grpc.credentials.createInsecure(): communication will be in plain text, i.e. non-encrypted
@@ -39,43 +70,39 @@ const sendgRPCRequest = (
     ipAddress ? ipAddress : `localhost:${port}`,
     grpc.credentials.createInsecure()
   );
+
   // invoke client object's method
   const call = client[`${method}`](message, (err, response) => {
-    if (err) console.log('error in grpc request: ', err);
+    if (err) {
+      let errorMessage: string = `ERROR: CODE ${err.code} - ${err.details}`;
+      displayOutputMessage(tropicChannel, service, method, message, errorMessage);
+      return null;
+    }
 
-    // generate formatted Request and Response message string
-    const requestStr = JSON.stringify(
-      {
-        service,
-        method,
-        message,
-      },
-      null,
-      2
-    );
+    // generate formatted response message string
     const responseStr = JSON.stringify(response, null, 2);
-    const outputMessage = `------------------------\n\nSUBMITTED REQUEST \n${requestStr}\n\nSERVER RESPONSE \n${responseStr}\n\n`;
 
-    // display request and response in tropic output channel
-    tropicChannel.show(true);
-    tropicChannel.append(outputMessage);
+    // display response in tropic output channel
+    displayOutputMessage(tropicChannel, service, method, message, responseStr);
 
     // exit function
     return null;
   });
 
+  // declare streamed varaible to store server streamed data
   const streamed: Array<object> = [];
+
   // method for server streaming; will return an object
-  call.on('data', (data) => {
-    console.log('received data from server: ', JSON.stringify(data));
-    streamed.push(data);
-  });
+  call.on('data', (data) => streamed.push(data));
+
   call.on('end', () => {
-    tropicChannel.append(
-      `------------------------\n\nSUBMITTED REQUEST \n${'requestStr'}\n\nSERVER RESPONSE \n`
-    );
-    tropicChannel.append(JSON.stringify(Object.assign({}, streamed), null, 2));
-    console.log('server done!');
+    // generate formatted response message string
+    const responseStr = JSON.stringify(Object.assign({}, streamed), null, 2);
+
+    // display response in tropic output channel
+    displayOutputMessage(tropicChannel, service, method, message, responseStr);
+
+    return null;
   });
 };
 


### PR DESCRIPTION
- sendgRPCRequest.ts
  - renamed outputMessage to outputTempalte
  - added comments to clarify flow
  - updated unary error handling to output error code and details to output channel (https://developers.google.com/maps-booking/reference/grpc-api-v2/status_codes)
  - removed console logs in sterver streaming handlers 
  - updated gRPC intialization comments
  - added check to confirm that protoPackage provided by user is valid
  - added check to confirm that service provided by user is valie
  - added check to confirm that method provided by user is valid
  - added ip address param info that was introduced in previous merge
  - added tropicChannel param info that was introduced last week

- displayOutputMessage.ts
  - created new function to handle displaying request and response to output channel
