### PR TITLE
updated server on technique

### DIFF
--- a/src/modules/commands/activateAndDeactivateCommand.ts
+++ b/src/modules/commands/activateAndDeactivateCommand.ts
@@ -41,7 +41,7 @@ const activateTropicCb = () => {
       serverProcess.stderr.on('data', (data) => {
         serverIsTurnedOn = false;
         vscode.window.showErrorMessage(
-          `There was an error starting your gRPC server. Please try manually starting it.`
+          `Error starting your gRPC server. Please try manually starting it.`
         );
       });
 
@@ -84,9 +84,9 @@ const deactivateTropicCb = () => {
   if (serverIsTurnedOn) {
     console.log('at end: ', serverProcess.pid);
     const killServerProcess = spawn('kill', [serverProcess.pid]);
-    setTimeout(() => killServerProcess.kill('SIGINT'), 0);
+    setTimeout(() => killServerProcess.kill('SIGINT'), 500);
     serverIsTurnedOn = false;
-    vscode.window.showInformationMessage(`gRPC server has been closed.`);
+    vscode.window.showInformationMessage(`gRPC server has been shut off.`);
   }
 
   vscode.window.showInformationMessage(`Tropic is deactivated`);

--- a/src/modules/commands/activateAndDeactivateCommand.ts
+++ b/src/modules/commands/activateAndDeactivateCommand.ts
@@ -1,9 +1,11 @@
 import * as vscode from 'vscode';
+import { ChildProcess, spawn } from 'child_process';
 
-// save listener, terminal, and output channel are declared globally within this file,
+// save listener, child process, and output channel are declared globally within this file,
 // to be accessible by activate and deactivate functions
 let saveListener: vscode.Disposable;
-let serverTerminal: vscode.Terminal;
+let serverProcess: ChildProcess;
+let serverIsTurnedOn: boolean;
 const tropicChannel = vscode.window.createOutputChannel('Tropic');
 
 // require in necessary files/modules
@@ -32,13 +34,25 @@ const activateTropicCb = () => {
   if (config.entry) {
     // confirm that the serverPath leads to a valid file
     if (fs.existsSync(serverPath)) {
-      serverTerminal = vscode.window.createTerminal();
-      serverTerminal.sendText(`node ${serverPath}`, true);
-      vscode.window.showInformationMessage('gRPC server has been started.');
+      // start the server with node
+      serverProcess = spawn('node', [serverPath], { cwd: rootDir });
+      serverIsTurnedOn = true;
+      // if an error is reported, inform user
+      serverProcess.stderr.on('data', (data) => {
+        serverIsTurnedOn = false;
+        vscode.window.showErrorMessage(
+          `There was an error starting your gRPC server. Please try manually starting it.`
+        );
+      });
+
+      // inform user that server is starting
+      setTimeout(() => {
+        if (serverIsTurnedOn) {
+          vscode.window.showInformationMessage('gRPC server has been started.');
+        }
+      }, 2500);
     } else {
-      vscode.window.showInformationMessage(
-        'Error in server path. Server was not started by Tropic.'
-      );
+      vscode.window.showErrorMessage('Error in server path. Server was not started by Tropic.');
     }
   }
 
@@ -66,9 +80,12 @@ const deactivateTropicCb = () => {
     saveListener.dispose();
   }
 
-  // close opened server, by disposing terminal
-  if (serverTerminal) {
-    serverTerminal.dispose();
+  // close opened server
+  if (serverIsTurnedOn) {
+    console.log('at end: ', serverProcess.pid);
+    const killServerProcess = spawn('kill', [serverProcess.pid]);
+    setTimeout(() => killServerProcess.kill('SIGINT'), 0);
+    vscode.window.showInformationMessage(`gRPC server has been closed.`);
   }
 
   vscode.window.showInformationMessage(`Tropic is deactivated`);

--- a/src/modules/commands/activateAndDeactivateCommand.ts
+++ b/src/modules/commands/activateAndDeactivateCommand.ts
@@ -85,6 +85,7 @@ const deactivateTropicCb = () => {
     console.log('at end: ', serverProcess.pid);
     const killServerProcess = spawn('kill', [serverProcess.pid]);
     setTimeout(() => killServerProcess.kill('SIGINT'), 0);
+    serverIsTurnedOn = false;
     vscode.window.showInformationMessage(`gRPC server has been closed.`);
   }
 


### PR DESCRIPTION
- activateAndDeactivateCommand.ts
  - new technique for staring server: using child-processes
  - imported ChildProcess and swan modules
  - renamed serverTerminal to serverProcess because of new technique 
  - created global variables serverIsTurnedOn
  - updated error messages to display as vscode error messages, rather than info messages

  - *********activateTropicCb function
  - executed node command to start server using child-process and spawn method
  - updated serverIsTurnedOn to true after
  - handled a possible error from command by updating serverIsTurnedOn to false and informing user to start server manually
  - waiting 2.5 seconds for any errors from command, then checked serverIsTurnedOn value, and informed the user if the server was turn on by Tropic
 
  - *********deactivateTropicCb function
  - if the server was turned on by Tropic, use spawn to kill server process
  - kill the process that killed the server process
  - inform user that the server has been closed
  - updated serverIsTurnedOn value to false, for subsequent activates and deactivates
